### PR TITLE
Parameterize min and max in filter_slider

### DIFF
--- a/R/controls.R
+++ b/R/controls.R
@@ -231,10 +231,6 @@ inlineCheckbox <- function(id, value, label) {
 #' @param sep Separator between thousands places in numbers.
 #' @param pre A prefix string to put in front of the value.
 #' @param post A suffix string to put after the value.
-#' @param dragRange This option is used only if it is a range slider (with two
-#'   values). If \code{TRUE} (the default), the range can be dragged. In other
-#'   words, the min and max can be dragged together. If \code{FALSE}, the range
-#'   cannot be dragged.
 #' @param timeFormat Only used if the values are Date or POSIXt objects. A time
 #'   format string, to be passed to the Javascript strftime library. See
 #'   \url{https://github.com/samsonjs/strftime} for more details. The allowed
@@ -247,7 +243,14 @@ inlineCheckbox <- function(id, value, label) {
 #'   \code{"+HHMM"} or \code{"-HHMM"}. If \code{NULL} (the default), times will
 #'   be displayed in the browser's time zone. The value \code{"+0000"} will
 #'   result in UTC time.
-#'
+#' @param dragRange This option is used only if it is a range slider (with two
+#'   values). If \code{TRUE} (the default), the range can be dragged. In other
+#'   words, the min and max can be dragged together. If \code{FALSE}, the range
+#'   cannot be dragged.
+#' @param min The leftmost value of the slider. By default, set to the minimal
+#'   number in input data.
+#' @param max The rightmost value of the slider. By default, set to the maximal
+#'   number in input data.
 #' @examples
 #' ## Only run examples in interactive R sessions
 #' if (interactive()) {

--- a/R/controls.R
+++ b/R/controls.R
@@ -260,7 +260,7 @@ inlineCheckbox <- function(id, value, label) {
 filter_slider <- function(id, label, sharedData, column, step = NULL,
   round = FALSE, ticks = TRUE, animate = FALSE, width = NULL, sep = ",",
   pre = NULL, post = NULL, timeFormat = NULL,
-  timezone = NULL, dragRange = TRUE)
+  timezone = NULL, dragRange = TRUE, min = NULL, max = NULL)
 {
   # TODO: Check that this works well with factors
   # TODO: Handle empty data frame, NA/NaN/Inf/-Inf values
@@ -272,8 +272,10 @@ filter_slider <- function(id, label, sharedData, column, step = NULL,
   df <- sharedData$data(withKey = TRUE)
   col <- lazyeval::f_eval(column, df)
   values <- na.omit(col)
-  min <- min(values)
-  max <- max(values)
+  if (is.null(min))
+    min <- min(values)
+  if (is.null(max))
+    max <- max(values)
   value <- range(values)
 
   ord <- order(col)

--- a/man/filter_slider.Rd
+++ b/man/filter_slider.Rd
@@ -7,7 +7,8 @@
 \usage{
 filter_slider(id, label, sharedData, column, step = NULL, round = FALSE,
   ticks = TRUE, animate = FALSE, width = NULL, sep = ",", pre = NULL,
-  post = NULL, timeFormat = NULL, timezone = NULL, dragRange = TRUE)
+  post = NULL, timeFormat = NULL, timezone = NULL, dragRange = TRUE,
+  min = NULL, max = NULL)
 
 animation_options(interval = 1000, loop = FALSE, playButton = NULL,
   pauseButton = NULL)
@@ -68,6 +69,12 @@ result in UTC time.}
 values). If \code{TRUE} (the default), the range can be dragged. In other
 words, the min and max can be dragged together. If \code{FALSE}, the range
 cannot be dragged.}
+
+\item{min}{The leftmost value of the slider. By default, set to the minimal
+number in input data.}
+
+\item{max}{The rightmost value of the slider. By default, set to the maximal
+number in input data.}
 
 \item{interval}{The interval, in milliseconds, between each animation step.}
 


### PR DESCRIPTION
Allows customizing `min` and `max` values. 

For instance, if you want to render from percentage values, none of which hit exact 0 or 100%. A slider from something like 3% to 97% might be not what you want, making it useful to force `min=0` and `max=1`.

Vlad