### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - npm install
   - grunt build
   - npm run coverage
-  - git diff --exit-code
+  - git diff --exit-code inst
 
 notifications:
   email:


### PR DESCRIPTION
Travis was failing because npm-shrinkwrap.json has some minor differences between platforms. We actually don't care about differences in npm-shrinkwrap.json, that `git diff --exit-code` line was in there to make sure the generated JavaScript that is committed is up-to-date with respect to the JavaScript source. So I changed the line to only diff the `inst` directory, where those assets are kept.