### PR TITLE
Fix #40: SharedData across shiny modules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## crosstalk 1.2.0.9000
 
+### Bug fixes
+
+* Some `SharedData` reactive accessors (e.g. `sd$selection()`) were broken when the `SharedData` instance was created in a Shiny module. (#114)
 
 ## crosstalk 1.2.0
 

--- a/R/crosstalk.R
+++ b/R/crosstalk.R
@@ -90,6 +90,13 @@ ClientValue <- R6Class(
     #'   session.
     initialize = function(name, group = "default", session = shiny::getDefaultReactiveDomain()) {
       if (!missing(session) || shinyInstalled()) {
+        if (!is.null(session)) {
+          # The name and group should be interpreted as global to the session,
+          # i.e. SharedData in two module instances with the same group name
+          # should be linked. Use the rootScope(), or else get() will prepend
+          # the module ID.
+          session <- session$rootScope()
+        }
         private$.session <- session
       } else {
         # If session wasn't explicitly provided and Shiny isn't installed, we can't use
@@ -212,7 +219,7 @@ SharedData <- R6Class(
 
       domain <- getDefaultReactiveDomain()
       if (!is.null(domain)) {
-        observe({
+        shiny::observe({
           selection <- private$.selectionCV$get()
           if (!is.null(selection) && length(selection) > 0) {
             private$.updateSelection(self$key() %in% selection)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crosstalk",
-  "version": "1.2.0",
+  "version": "1.2.0-alpha.9000",
   "description": "",
   "main": "inst/www/js/crosstalk.js",
   "directories": {

--- a/tests/testthat/test-crosstalk.R
+++ b/tests/testthat/test-crosstalk.R
@@ -74,3 +74,26 @@ test_that("SharedData basic scenarios with shiny 'uninstalled'", {
     }
   }
 })
+
+test_that("Shiny modules support SharedData", {
+  sess <- shiny::MockShinySession$new()
+  sd1 <- shiny::withReactiveDomain(sess, {
+    SharedData$new(cars, group = "foo")
+  })
+  sd2 <- shiny::withReactiveDomain(sess$makeScope("module1"), {
+    SharedData$new(cars, group = "foo")
+  })
+
+  sess$setInputs(".clientValue-foo-selection" = c("1", "2"))
+
+  res <- c(TRUE, TRUE, rep_len(FALSE, nrow(cars) - 2))
+  expect_identical(shiny::isolate(sd1$selection()), res)
+  expect_identical(shiny::isolate(sd2$selection()), res)
+
+  sess$setInputs(".clientValue-foo-selection" = c("49", "50"))
+
+  res2 <- c(rep_len(FALSE, nrow(cars) - 2), TRUE, TRUE)
+  expect_identical(shiny::isolate(sd1$selection()), res2)
+  expect_identical(shiny::isolate(sd2$selection()), res2)
+
+})

--- a/tests/testthat/test-crosstalk.R
+++ b/tests/testthat/test-crosstalk.R
@@ -90,9 +90,9 @@ test_that("Shiny modules support SharedData", {
   expect_identical(shiny::isolate(sd1$selection()), res)
   expect_identical(shiny::isolate(sd2$selection()), res)
 
-  sess$setInputs(".clientValue-foo-selection" = c("49", "50"))
+  res2 <- rev(res)
+  sess$setInputs(".clientValue-foo-selection" = as.character(which(res2)))
 
-  res2 <- c(rep_len(FALSE, nrow(cars) - 2), TRUE, TRUE)
   expect_identical(shiny::isolate(sd1$selection()), res2)
   expect_identical(shiny::isolate(sd2$selection()), res2)
 


### PR DESCRIPTION
SharedData group should transcend modules (it's a global
namespace). This isn't as crazy as it sounds, because
the default group value is a random ID.

`SharedData$new(..., group = session$ns("groupname"))` can
be used to opt into namespaces if that's desired.

Note that this change doesn't break a scenario that works
today; before this commit, the reactive accessors on
SharedData that originated in modules, simply did not work.

## TODO

- [ ] Card
- [x] Testing notes
- [x] Example app

## Testing notes

Run the following app. Select some points on the plot. Without the fix, the reported number of selected points is 0; with the fix, a correct number is reported. (Note that it might sometimes seem like the reported number is a little too high--this is because of overplotted points, and is almost certainly actually the correct number.)

```r
library(shiny)
library(crosstalk)
library(plotly)

modUI <- function(id) {
  ns <- NS(id)
  tagList(
    p(
      "Number of points selected:",
      textOutput(ns("count"), container = strong)
    ),
    plotlyOutput(ns("plotly1"))
  )
}

mod <- function(id) {
  moduleServer(id, function(input, output, session) {
    sd <- SharedData$new(cars, group = "a")
    output$plotly1 <- renderPlotly({
      plot_ly(sd, type = "scatter", mode = "markers", x = ~ speed, y = ~ dist) %>%
        highlight("plotly_selected")
    })
    output$count <- renderText({
      sum(sd$selection())
    })
  })
}


ui <- basicPage(
  p(
    strong("Instructions:"),
    "Select some points in the plot, and make sure ",
    "'Number of points selected:' shows the correct value."
  ),
  hr(),
  modUI("one")
)

server <- function(input, output, session) {
  mod("one")
}

shinyApp(ui, server)
```