### PR TITLE
Mark `filter_select()` json as HTML

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * Some `SharedData` reactive accessors (e.g. `sd$selection()`) were broken when the `SharedData` instance was created in a Shiny module. (#114)
+* Closed #87: Fixed an issue where `filter_select()` was double escaping HTML characters. (#141)
 
 ## crosstalk 1.2.0
 

--- a/R/controls.R
+++ b/R/controls.R
@@ -164,7 +164,9 @@ filter_select <- function(id, label, sharedData, group, allLevels = FALSE,
         ),
         tags$script(type = "application/json",
           `data-for` = id,
-          jsonlite::toJSON(options, dataframe = "columns", pretty = TRUE)
+          HTML(
+            jsonlite::toJSON(options, dataframe = "columns", pretty = TRUE)
+          )
         )
       )
     ),


### PR DESCRIPTION
Fixes #87

This is a small change to mark as HTML the jsonified `options` passed from `filter_select()` to the crosstalk input select widget. Because selectize applies its own HTML escaping, we end up with double-escaped option names, making it impossible to represent characters such as `&` in the options dropdown.

This change is **not applied** to `filter_checkbox()`, because a second round of escaping does't occur client-side.

Here's a minimal reprex:

```r
# library(crosstalk)
pkgload::load_all()

df <- data.frame(
  points = c(10, 12, 14, 21),
  stadium = c(
    "M & T Bank Stadium",
    "Wembley Stadium",
    "FirstBank Stadium",
    "<script>alert('oh-no')</script>"
  )
)

df_crosstalk <- SharedData$new(df)

bscols(
  filter_select(
    id = "stadium_select",
    label = "Stadium Select",
    sharedData = df_crosstalk,
    group = ~`stadium`
  ),
  filter_checkbox(
    id = "stadium_check",
    label = "Stadium Check",
    sharedData = df_crosstalk,
    group = ~`stadium`
  )
)
```

## Before

Before this change, the `&` is rendered as a literal `&amp;` (escaped HTML) and the `<script>` tag is also rendered as double-escaped HTML.

![image](https://github.com/rstudio/crosstalk/assets/5420529/a62debdb-233a-4e8c-98b8-eebd97e1207a)


## After

After this change, the `&` is rendered as HTML `&amp;` and the `<script>` tag appears as literal character strings, and importantly not as a `<script>` tag, showing that selectize is correctly escaping the option labels (and no alert is shown).

![image](https://github.com/rstudio/crosstalk/assets/5420529/bb72bd3d-ddde-41b2-8a6c-2e85313e541c)
