### PR TITLE
chore: address R CMD check NOTE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,52 +1,53 @@
-Package: crosstalk
 Type: Package
+Package: crosstalk
 Title: Inter-Widget Interactivity for HTML Widgets
 Version: 1.2.1.9000
 Authors@R: c(
-    person("Joe", "Cheng", role = "aut", email = "joe@posit.co"),
-    person("Carson", "Sievert", role = c("aut", "cre"),
-    email = "carson@posit.co", comment = c(ORCID = "0000-0002-4958-2844")),
+    person("Joe", "Cheng", , "joe@posit.co", role = "aut"),
+    person("Carson", "Sievert", , "carson@posit.co", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-4958-2844")),
     person("Posit Software, PBC", role = c("cph", "fnd")),
-    person(family = "jQuery Foundation", role = "cph",
-    comment = "jQuery library and jQuery UI library"),
-    person(family = "jQuery contributors", role = c("ctb", "cph"),
-    comment = "jQuery library; authors listed in inst/www/shared/jquery-AUTHORS.txt"),
+    person(, "jQuery Foundation", role = "cph",
+           comment = "jQuery library and jQuery UI library"),
+    person(, "jQuery contributors", role = c("ctb", "cph"),
+           comment = "jQuery library; authors listed in inst/www/shared/jquery-AUTHORS.txt"),
     person("Mark", "Otto", role = "ctb",
-    comment = "Bootstrap library"),
+           comment = "Bootstrap library"),
     person("Jacob", "Thornton", role = "ctb",
-    comment = "Bootstrap library"),
-    person(family = "Bootstrap contributors", role = "ctb",
-    comment = "Bootstrap library"),
-    person(family = "Twitter, Inc", role = "cph",
-    comment = "Bootstrap library"),
+           comment = "Bootstrap library"),
+    person(, "Bootstrap contributors", role = "ctb",
+           comment = "Bootstrap library"),
+    person(, "Twitter, Inc", role = "cph",
+           comment = "Bootstrap library"),
     person("Brian", "Reavis", role = c("ctb", "cph"),
-    comment = "selectize.js library"),
+           comment = "selectize.js library"),
     person("Kristopher Michael", "Kowal", role = c("ctb", "cph"),
-    comment = "es5-shim library"),
-    person(family = "es5-shim contributors", role = c("ctb", "cph"),
-    comment = "es5-shim library"),
+           comment = "es5-shim library"),
+    person(, "es5-shim contributors", role = c("ctb", "cph"),
+           comment = "es5-shim library"),
     person("Denis", "Ineshin", role = c("ctb", "cph"),
-    comment = "ion.rangeSlider library"),
+           comment = "ion.rangeSlider library"),
     person("Sami", "Samhuri", role = c("ctb", "cph"),
-    comment = "Javascript strftime library")
-    )
-Description: Provides building blocks for allowing HTML widgets to communicate
-    with each other, with Shiny or without (i.e. static .html files). Currently
-    supports linked brushing and filtering.
+           comment = "Javascript strftime library")
+  )
+Description: Provides building blocks for allowing HTML widgets to
+    communicate with each other, with Shiny or without (i.e. static .html
+    files). Currently supports linked brushing and filtering.
 License: MIT + file LICENSE
+URL: https://rstudio.github.io/crosstalk/,
+    https://github.com/rstudio/crosstalk
+BugReports: https://github.com/rstudio/crosstalk/issues
 Imports:
     htmltools (>= 0.3.6),
     jsonlite,
     lazyeval,
     R6
 Suggests:
-    shiny,
+    bslib,
     ggplot2,
-    testthat (>= 2.1.0),
     sass,
-    bslib
+    shiny,
+    testthat (>= 2.1.0)
 Config/Needs/website: jcheng5/d3scatter, DT, leaflet, rmarkdown
-URL: https://rstudio.github.io/crosstalk/, https://github.com/rstudio/crosstalk
-BugReports: https://github.com/rstudio/crosstalk/issues
-RoxygenNote: 7.3.2
 Encoding: UTF-8
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # crosstalk (development version)
 
+Address a new R CMD check NOTE about Rd \link{} targets missing package anchors. ()
+
 ## crosstalk 1.2.1
 
 ### Bug fixes

--- a/R/controls.R
+++ b/R/controls.R
@@ -482,15 +482,16 @@ hasDecimals <- function(value) {
 #' @rdname filter_slider
 #'
 #' @param interval The interval, in milliseconds, between each animation step.
-#' @param loop \code{TRUE} to automatically restart the animation when it
+#' @param loop `TRUE` to automatically restart the animation when it
 #'   reaches the end.
 #' @param playButton Specifies the appearance of the play button. Valid values
 #'   are a one-element character vector (for a simple text label), an HTML tag
-#'   or list of tags (using \code{\link{tag}} and friends), or raw HTML (using
-#'   \code{\link{HTML}}).
-#' @param pauseButton Similar to \code{playButton}, but for the pause button.
+#'   or list of tags (using [htmltools::tag] and friends), or raw HTML (using
+#'   [htmltools::HTML()]).
+#' @param pauseButton Similar to `playButton`, but for the pause button.
 #'
 #' @export
+#' @md
 animation_options <- function(interval=1000,
   loop=FALSE,
   playButton=NULL,
@@ -603,4 +604,3 @@ formatNoSci <- function(x) {
   if (is.null(x)) return(NULL)
   format(x, scientific = FALSE, digits = 15)
 }
-

--- a/man/filter_slider.Rd
+++ b/man/filter_slider.Rd
@@ -102,8 +102,8 @@ reaches the end.}
 
 \item{playButton}{Specifies the appearance of the play button. Valid values
 are a one-element character vector (for a simple text label), an HTML tag
-or list of tags (using \code{\link{tag}} and friends), or raw HTML (using
-\code{\link{HTML}}).}
+or list of tags (using \link[htmltools:builder]{htmltools::tag} and friends), or raw HTML (using
+\code{\link[htmltools:HTML]{htmltools::HTML()}}).}
 
 \item{pauseButton}{Similar to \code{playButton}, but for the pause button.}
 }


### PR DESCRIPTION
Address the new R CMD check NOTE

https://cran.r-project.org/web/checks/check_results_crosstalk.html

```
Version: 1.2.1
Check: Rd cross-references
Result: NOTE 
  Found the following Rd file(s) with Rd \link{} targets missing package
  anchors:
    filter_slider.Rd: tag, HTML
  Please provide package anchors for all Rd \link{} targets not in the
  package itself and the base packages.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/crosstalk-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/crosstalk-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/crosstalk-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/crosstalk-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/crosstalk-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/crosstalk-00check.html)
```